### PR TITLE
Make bucket_type, ram_quota, num_replicas optional in CreateBucketRequest

### DIFF
--- a/couchbase/admin/bucket/v1/bucket.proto
+++ b/couchbase/admin/bucket/v1/bucket.proto
@@ -71,9 +71,9 @@ message ListBucketsResponse {
 
 message CreateBucketRequest {
   string bucket_name = 1;
-  BucketType bucket_type = 2;
-  uint64 ram_quota_bytes = 3;
-  uint32 num_replicas = 4;
+  optional BucketType bucket_type = 2;
+  optional uint64 ram_quota_bytes = 3;
+  optional uint32 num_replicas = 4;
   optional bool flush_enabled = 5;
   optional bool replica_indexes = 6;
   optional EvictionMode eviction_mode = 7;


### PR DESCRIPTION
Only `bucket_name` is required in many (all?) SDKs, at least in Java, Ruby and Python. `bucket_type`, `ram_quota` and `num_replicas` have default values