### PR TITLE
ING-1115: Add status field to GetAllReplicasResponse

### DIFF
--- a/couchbase/kv/v1/kv.proto
+++ b/couchbase/kv/v1/kv.proto
@@ -422,4 +422,5 @@ message GetAllReplicasResponse {
   bytes content = 2;
   uint32 content_flags = 3;
   uint64 cas = 4;
+  google.rpc.Status status = 5;
 }


### PR DESCRIPTION
So that we can return errors from replica reads without terminating the GRPC results stream we need the additional status field in GetAllReplicas response. 